### PR TITLE
Update stored & displayed project params when they're changed in the backing file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sketchbook2",
-            "version": "0.0.11",
+            "version": "0.0.12",
             "dependencies": {
                 "@types/js-cookie": "^3.0.3",
                 "canvas-sketch": "^0.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sketchbook2",
-            "version": "0.0.10",
+            "version": "0.0.11",
             "dependencies": {
                 "@types/js-cookie": "^3.0.3",
                 "canvas-sketch": "^0.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/src/art/CanvasSketchDemo/config.json
+++ b/src/art/CanvasSketchDemo/config.json
@@ -26,7 +26,7 @@
         },
         "bgSize": {
             "name": "Background Size",
-            "applyDuringInput": true,
+            "applyDuringInput": false,
             "section": "Sizes",
             "style": "compactField"
         },

--- a/src/art/ParamExamples/ParamExamples.ts
+++ b/src/art/ParamExamples/ParamExamples.ts
@@ -53,7 +53,7 @@ export default class AllParams extends Project {
 
     // Numeric arrays
     numericArrayDefault = [0.1, 0.9];
-    numericArraySliderOnly = [4, 1, 3];
+    numericArraySliderOnly = [1, 1, 3];
     numericArrayFieldOnly = [0.3, 0.8];
     numericArrayCompactSlider = [0.1, 0.9, 0.8, 0.4];
     numericArrayCompactField = [0.2, 0.7];

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -29,7 +29,7 @@ const panelMouseTriggerWidth = 50;
 const hidePanelButtonsTimeout: number | undefined = 2000;
 
 // Project and group label sorting
-const projectSortOrder = SortOrder.Chronological;
+const projectSortOrder = SortOrder.Alphabetical;
 const groupSortOrder = SortOrder.Alphabetical;
 
 // Anything listed here will appear in the user settings panel with the given label. Values changed

--- a/src/lib/base/FileLoading/ProjectLoader.ts
+++ b/src/lib/base/FileLoading/ProjectLoader.ts
@@ -140,7 +140,7 @@ export default class ProjectLoader {
         // Set project properties to stored values
         if (browser) {
             for (const param of params) {
-                const storedValue = ParamValueProvider.getValue(param, props.title, project);
+                const storedValue = ParamValueProvider.getValue(param, props.title, project, true);
                 if (typeof storedValue === 'function') continue;
                 Object.defineProperty(project, param.key, {
                     value: storedValue,

--- a/src/lib/base/Util/ParamValueProvider.ts
+++ b/src/lib/base/Util/ParamValueProvider.ts
@@ -69,6 +69,6 @@ export default class ParamValueProvider {
     }
 
     static #localStorageKey(projectKey: string, paramKey: string): string {
-        return `${projectKey} - ${paramKey}`;
+        return `${projectKey}_${paramKey}`;
     }
 }

--- a/src/lib/base/Util/PersistedStore.ts
+++ b/src/lib/base/Util/PersistedStore.ts
@@ -3,14 +3,14 @@ import { writable } from 'svelte/store';
 import type { AnyParamValueType } from '../ParamConfig/ParamTypes';
 
 /**
- * Custom Svelte store that enables persistence of only specified entries in local storage.
- * These values will be reset to their initial values when these initial values change, so default
- * value updates will be reflected on next load.
+ * Custom Svelte store that enables persistence of only specified entries in either localStorage
+ * or cookies. These values will be reset to their initial values when these initial values change,
+ * so default value updates will be reflected on next load during development.
  *
- * @param storeKey The key to use for this store in local storage
+ * @param storeKey The key to use for this store (will be prefixed to all keys)
  * @param initialValues The initial values for this store
  * @param persistKeys The keys to persist (if not specified, all keys will be persisted)
- * @param useCookies Whether to use cookies instead of local storage
+ * @param useCookies Whether to use cookies instead of local storage (e.g. if needed in requests)
  */
 export function createPersistedStore<T>(
     storeKey: string,
@@ -51,7 +51,7 @@ export function createPersistedStore<T>(
                 continue;
             }
 
-            // Otherwise, use the value in local storage
+            // Otherwise, use the stored value
             const value = getItem(key, useCookies) || initialValue;
             initialState[key] = JSON.parse(value);
         }

--- a/src/lib/components/ProjectParams.svelte
+++ b/src/lib/components/ProjectParams.svelte
@@ -69,11 +69,13 @@
 
     // Get the properly typed initial value for a given param
     function initialValueForParam<T extends ParamConfig>(paramConfig: T): ParamValueType<T> {
-        return ParamValueProvider.getValue(
-            paramConfig,
-            projectTuple.config.title,
-            projectTuple.project
-        );
+        const objectValue = Object.getOwnPropertyDescriptor(
+            projectTuple.project,
+            paramConfig.key
+        )?.value;
+
+        // If it's an array, we need to copy it so that we don't mutate the original
+        return Array.isArray(objectValue) ? [...objectValue] : objectValue;
     }
 </script>
 

--- a/tests/component/ProjectParams.test.ts
+++ b/tests/component/ProjectParams.test.ts
@@ -119,7 +119,7 @@ function renderParams(
 
     const updateHandler = vi.fn();
     component.$on('paramupdated', updateHandler);
-    expect(ParamValueProvider.getValue).toHaveBeenCalledTimes(6);
+    expect(ParamValueProvider.getValue).toHaveBeenCalledTimes(0);
     expect(ParamValueProvider.setValue).toHaveBeenCalledTimes(0);
     expect(updateHandler).toHaveBeenCalledTimes(0);
     return { project, updateHandler };

--- a/tests/unit/ProjectLoader.test.ts
+++ b/tests/unit/ProjectLoader.test.ts
@@ -252,8 +252,8 @@ describe('loading specific projects, in browser mode (re: stored values)', async
     it('loads a project with no config file', async () => {
         // Mock stored values
         const mockParamValueFn = vi.fn((key: string) => {
-            if (key === 'NoConfig - testNumber') return '32';
-            if (key === 'NoConfig - testNumericArray') return '[4, 5, 6]';
+            if (key === 'NoConfig_testNumber') return '32';
+            if (key === 'NoConfig_testNumericArray') return '[4, 5, 6]';
             return null;
         });
         vi.spyOn(Storage.prototype, 'getItem').mockImplementation(mockParamValueFn);
@@ -283,8 +283,8 @@ describe('loading specific projects, in browser mode (re: stored values)', async
     it('loads a project with a config file', async () => {
         // Mock stored values
         const mockParamValueFn = vi.fn((key: string) => {
-            if (key === 'Config and Support - testNumber') return '32';
-            if (key === 'Config and Support - testString') return '"hello world"';
+            if (key === 'Config and Support_testNumber') return '32';
+            if (key === 'Config and Support_testString') return '"hello world"';
             return null;
         });
         vi.spyOn(Storage.prototype, 'getItem').mockImplementation(mockParamValueFn);


### PR DESCRIPTION
This is a developer friendly feature. Even if you have stored parameter values, you'll want to see any updates you make in the instance variable values (i.e. default param values) in your backing Project subclass immediately.