### PR TITLE
Canvas size customizability

### DIFF
--- a/docs/docs_notes/core-concepts.md
+++ b/docs/docs_notes/core-concepts.md
@@ -34,6 +34,8 @@ Setting any of these properties directly after a project is initialized is unsup
 
 ### resized
 
+Note: dimensions are element sizes – canvas sizing is styled size in the DOM, not internal drawing size
+
 ### destroy
 
 # config.json
@@ -44,9 +46,9 @@ Param config & project config options (JSON fields) - maybe in a different file?
 
 -   time (in projects)
 -   canvas size // resizing the canvas
-    -   max at 100%
-    -   need to set style size to change the way it's presented (but that's cool)
+    -   max at 100%, relevant for both project config & direct size settings
     -   internal canvas size will sync to style size, and will apply pixelRatio
+    -   if you set style size to change the way it's presented, also set internal size!
 -   mouse position & clicks
 -   instance variables (#ivar)
 

--- a/docs/docs_notes/core-concepts.md
+++ b/docs/docs_notes/core-concepts.md
@@ -43,7 +43,7 @@ Param config & project config options (JSON fields) - maybe in a different file?
 # Common necessities:
 
 -   time (in projects)
--   canvas size
+-   canvas size // resizing the canvas
 -   mouse position & clicks
 -   instance variables (#ivar)
 

--- a/docs/docs_notes/core-concepts.md
+++ b/docs/docs_notes/core-concepts.md
@@ -44,6 +44,9 @@ Param config & project config options (JSON fields) - maybe in a different file?
 
 -   time (in projects)
 -   canvas size // resizing the canvas
+    -   max at 100%
+    -   need to set style size to change the way it's presented (but that's cool)
+    -   internal canvas size will sync to style size, and will apply pixelRatio
 -   mouse position & clicks
 -   instance variables (#ivar)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sketchbook2",
-            "version": "0.0.23",
+            "version": "0.0.24",
             "dependencies": {
                 "@types/js-cookie": "^3.0.3",
                 "canvas-sketch": "^0.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sketchbook2",
-            "version": "0.0.21",
+            "version": "0.0.22",
             "dependencies": {
                 "@types/js-cookie": "^3.0.3",
                 "canvas-sketch": "^0.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sketchbook2",
-            "version": "0.0.22",
+            "version": "0.0.23",
             "dependencies": {
                 "@types/js-cookie": "^3.0.3",
                 "canvas-sketch": "^0.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.24",
+    "version": "0.0.27",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sketchbook2",
-            "version": "0.0.24",
+            "version": "0.0.27",
             "dependencies": {
                 "@types/js-cookie": "^3.0.3",
                 "canvas-sketch": "^0.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.24",
+    "version": "0.0.27",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sketchbook2",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/src/art/CanvasSketchDemo/CanvasSketchDemo.ts
+++ b/src/art/CanvasSketchDemo/CanvasSketchDemo.ts
@@ -64,9 +64,8 @@ export default class CanvasSketchDemo extends Project {
 
     async init() {
         this.#sketchManager = await canvasSketch(this.#sketchFn, {
-            dimensions: [1000, 1500],
             canvas: this.canvas,
-            resizeCanvas: true,
+            resizeCanvas: false,
             animate: true,
             hotkeys: false // todo; can we still enable save hotkey without enabling play toggling with space
         });

--- a/src/art/CanvasSketchDemo/CanvasSketchDemo.ts
+++ b/src/art/CanvasSketchDemo/CanvasSketchDemo.ts
@@ -64,8 +64,9 @@ export default class CanvasSketchDemo extends Project {
 
     async init() {
         this.#sketchManager = await canvasSketch(this.#sketchFn, {
+            dimensions: [1000, 1000],
             canvas: this.canvas,
-            resizeCanvas: false,
+            resizeCanvas: true,
             animate: true,
             hotkeys: false // todo; can we still enable save hotkey without enabling play toggling with space
         });
@@ -74,6 +75,10 @@ export default class CanvasSketchDemo extends Project {
     update() {
         if (this.#sketchManager && this.#sketchManager.settings.animate) return;
         this.#sketchManager?.render();
+    }
+
+    resized() {
+        this.#sketchManager?.update();
     }
 
     destroy() {

--- a/src/art/CanvasSketchDemo/CanvasSketchDemo.ts
+++ b/src/art/CanvasSketchDemo/CanvasSketchDemo.ts
@@ -64,8 +64,9 @@ export default class CanvasSketchDemo extends Project {
 
     async init() {
         this.#sketchManager = await canvasSketch(this.#sketchFn, {
+            dimensions: [1000, 1500],
             canvas: this.canvas,
-            resizeCanvas: false,
+            resizeCanvas: true,
             animate: true,
             hotkeys: false // todo; can we still enable save hotkey without enabling play toggling with space
         });

--- a/src/art/DemoProject1/DemoProject1.ts
+++ b/src/art/DemoProject1/DemoProject1.ts
@@ -34,7 +34,7 @@ export default class DemoProject extends Project {
 
     stringOptions = 'Second';
 
-    arrayColor = [255, 21, 0];
+    arrayColor = [45, 200, 100];
 
     #xPos = 300;
     update({ frame }: { frame: number; time: number }) {
@@ -43,11 +43,11 @@ export default class DemoProject extends Project {
         if (!ctx) throw new Error('Could not get 2D context');
         ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
+        ctx.fillStyle = `rgb(${this.arrayColor[0]}, ${this.arrayColor[1]}, ${this.arrayColor[2]})`;
+        ctx.fillRect(0, 0, 2000, 400);
+
         ctx.fillStyle = this.testColor;
         this.#xPos = frame % this.canvas.width;
         ctx.fillRect(this.#xPos, 300, 550, 700);
-
-        ctx.fillStyle = `rgb(${this.arrayColor[0]}, ${this.arrayColor[1]}, ${this.arrayColor[2]})`;
-        ctx.fillRect(400, 400, 550, 700);
     }
 }

--- a/src/art/DemoProject1/config.json
+++ b/src/art/DemoProject1/config.json
@@ -5,6 +5,8 @@
     "groups": ["Print Media", "Test Category"],
     "experimental": false,
     "paramsApplyDuringInput": true,
+    "canvasSize": [2000, 1000],
+    "pixelRatio": 4,
 
     "params": {
         "testNumber": {

--- a/src/art/DemoProject2/DemoProject2.ts
+++ b/src/art/DemoProject2/DemoProject2.ts
@@ -21,8 +21,6 @@ export default class DemoProject extends Project {
 
     update() {
         if (!this.canvas) throw new Error('Canvas not set');
-        this.canvas.style.width = `${this.dimensions[0] * 100}%`;
-        this.canvas.style.height = `${this.dimensions[1] * 100}%`;
         const ctx = this.canvas.getContext('2d');
         if (!ctx) throw new Error('Could not get 2D context');
         ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
@@ -30,5 +28,9 @@ export default class DemoProject extends Project {
         if (this.#bundledImage && this.testBoolean)
             ctx.drawImage(this.#bundledImage, 0, 0, this.canvas.width, this.canvas.height);
         ctx.fillRect(200, 200, this.size * this.canvas.width, this.size * this.canvas.height);
+        this.canvas.style.width = `${this.dimensions[0] * 100}%`;
+        this.canvas.style.height = `${this.dimensions[1] * 100}%`;
+        // todo: setting style width here doesn't work as expected;
+        // adjust dimensions param, then adjust canvas size - rect jumps around
     }
 }

--- a/src/art/DemoProject2/DemoProject2.ts
+++ b/src/art/DemoProject2/DemoProject2.ts
@@ -4,6 +4,7 @@ import TestImage from './test-image.png';
 export default class DemoProject extends Project {
     testBoolean = true;
     size = 0.2;
+    dimensions = [0.5, 0.5];
 
     #bundledImage: HTMLImageElement;
 
@@ -20,11 +21,12 @@ export default class DemoProject extends Project {
 
     update() {
         if (!this.canvas) throw new Error('Canvas not set');
+        this.canvas.style.width = `${this.dimensions[0] * 100}%`;
+        this.canvas.style.height = `${this.dimensions[1] * 100}%`;
         const ctx = this.canvas.getContext('2d');
         if (!ctx) throw new Error('Could not get 2D context');
         ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
         ctx.fillStyle = '#00FF00';
-        // console.log(this.canvas.width, this.canvas.height);
         if (this.#bundledImage && this.testBoolean)
             ctx.drawImage(this.#bundledImage, 0, 0, this.canvas.width, this.canvas.height);
         ctx.fillRect(200, 200, this.size * this.canvas.width, this.size * this.canvas.height);

--- a/src/art/DemoProject2/DemoProject2.ts
+++ b/src/art/DemoProject2/DemoProject2.ts
@@ -21,6 +21,12 @@ export default class DemoProject extends Project {
 
     update() {
         if (!this.canvas) throw new Error('Canvas not set');
+
+        this.canvas.style.width = `${this.dimensions[0] * 100}%`;
+        this.canvas.width = this.canvas.clientWidth * 2;
+        this.canvas.style.height = `${this.dimensions[1] * 100}%`;
+        this.canvas.height = this.canvas.clientHeight * 2;
+
         const ctx = this.canvas.getContext('2d');
         if (!ctx) throw new Error('Could not get 2D context');
         ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
@@ -28,9 +34,5 @@ export default class DemoProject extends Project {
         if (this.#bundledImage && this.testBoolean)
             ctx.drawImage(this.#bundledImage, 0, 0, this.canvas.width, this.canvas.height);
         ctx.fillRect(200, 200, this.size * this.canvas.width, this.size * this.canvas.height);
-        this.canvas.style.width = `${this.dimensions[0] * 100}%`;
-        this.canvas.style.height = `${this.dimensions[1] * 100}%`;
-        // todo: setting style width here doesn't work as expected;
-        // adjust dimensions param, then adjust canvas size - rect jumps around
     }
 }

--- a/src/art/P5Demo/P5Demo.ts
+++ b/src/art/P5Demo/P5Demo.ts
@@ -2,15 +2,15 @@ import P5Project from '$lib/base/Project/P5Project';
 import type P5 from 'p5';
 
 export default class P5Demo extends P5Project {
-    showRect = false;
+    showRect = true;
     rectSize = 0.5;
 
-    #pos = 400;
+    #pos = 200;
 
     draw(p5: P5) {
         p5.background(100);
         p5.fill(60, 100, 0);
-        if (this.showRect) p5.rect(this.#pos, 400, this.rectSize * 200, this.rectSize * 200);
+        if (this.showRect) p5.rect(this.#pos, 200, this.rectSize * 200, this.rectSize * 200);
         this.#pos = (this.#pos + 1) % p5.width;
     }
 }

--- a/src/config/theme.scss
+++ b/src/config/theme.scss
@@ -17,7 +17,7 @@ $small-text-size: 0.8rem;
 $xs-text-size: 0.7rem;
 
 $app-bg-color: #000; // for header on mobile safari
-$container-bg-color: #ddd; // color behind canvas, if canvas is not full screen
+$container-bg-color: #777; // color behind canvas, if canvas is not full screen
 $canvas-bg-color: #fff; // default canvas background color
 $canvas-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.5);
 

--- a/src/config/theme.scss
+++ b/src/config/theme.scss
@@ -16,6 +16,11 @@ $medium-text-size: 0.9rem;
 $small-text-size: 0.8rem;
 $xs-text-size: 0.7rem;
 
+$app-bg-color: #000; // for header on mobile safari
+$container-bg-color: #ddd; // color behind canvas, if canvas is not full screen
+$canvas-bg-color: #fff; // default canvas background color
+$canvas-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.5);
+
 // Panel buttons
 @mixin panel-show-button {
     font-size: 0.9rem;

--- a/src/lib/base/ConfigModels/ProjectConfig.ts
+++ b/src/lib/base/ConfigModels/ProjectConfig.ts
@@ -7,6 +7,8 @@ export interface ProjectConfig {
     presetsAvailable: boolean;
     experimental: boolean;
     paramsApplyDuringInput: boolean;
+    canvasSize?: [number, number];
+    pixelRatio?: number;
 }
 
 export const ProjectConfigDefaults: ProjectConfig = {
@@ -17,5 +19,7 @@ export const ProjectConfigDefaults: ProjectConfig = {
     groups: [],
     presetsAvailable: false,
     experimental: false,
-    paramsApplyDuringInput: true
+    paramsApplyDuringInput: true,
+    canvasSize: undefined,
+    pixelRatio: undefined
 };

--- a/src/lib/components/MainView/MainView.svelte
+++ b/src/lib/components/MainView/MainView.svelte
@@ -182,6 +182,8 @@
         <ProjectViewer
             project={selectedProjectTuple.project}
             containerResizing={!$settingsStore.overlayPanels && panelResizing}
+            canvasSizeConfig={selectedProjectTuple.config.canvasSize}
+            pixelRatioConfig={selectedProjectTuple.config.pixelRatio}
             bind:this={viewer}
         />
     </div>

--- a/src/lib/components/MainView/ProjectViewer.svelte
+++ b/src/lib/components/MainView/ProjectViewer.svelte
@@ -74,10 +74,6 @@
             throw new Error("Cannot update a project when the container doesn't exist");
         }
 
-        // When loading a first project or changing the canvas type, resize the canvas
-        const shouldResize =
-            !previousProject || previousProject.canvasType !== newProject.canvasType;
-
         // Track the previous project so we can destroy it
         previousProject?.destroy();
         previousProject = newProject;
@@ -108,7 +104,7 @@
         startTime = Date.now();
     }
 
-    // Called to reset the canvas size to match the container
+    // Called to reset the canvas size to the container size, or to a configured size
     function setCanvasSize(initializingProject = false) {
         const pixelRatio = pixelRatioConfig ?? window.devicePixelRatio;
 
@@ -129,10 +125,23 @@
         // Update the internal canvas sizes to match their style sizing
         if (!containerElement)
             throw new Error("Cannot set canvas size when the container doesn't exist");
-        canvasElement2D.width = canvasElement2D.offsetWidth * pixelRatio;
-        canvasElement2D.height = canvasElement2D.offsetHeight * pixelRatio;
-        canvasElementWebGL.width = canvasElementWebGL.offsetWidth * pixelRatio;
-        canvasElementWebGL.height = canvasElementWebGL.offsetHeight * pixelRatio;
+        const initialCanvasSize: [number, number] = [
+            // these values are used if client sizes return 0, e.g. if display: none
+            canvasSizeConfig ? canvasSizeConfig[0] : pixelRatio * containerElement.clientWidth,
+            canvasSizeConfig ? canvasSizeConfig[1] : pixelRatio * containerElement.clientHeight
+        ];
+        canvasElement2D.width = canvasElement2D.clientWidth
+            ? pixelRatio * canvasElement2D.clientWidth
+            : initialCanvasSize[0];
+        canvasElement2D.height = canvasElement2D.clientHeight
+            ? pixelRatio * canvasElement2D.clientHeight
+            : initialCanvasSize[1];
+        canvasElementWebGL.width = canvasElementWebGL.clientWidth
+            ? pixelRatio * canvasElementWebGL.clientWidth
+            : initialCanvasSize[0];
+        canvasElementWebGL.height = canvasElementWebGL.clientHeight
+            ? pixelRatio * canvasElementWebGL.clientHeight
+            : initialCanvasSize[1];
 
         // Call the project's resize method (if not initializing)
         if (initializingProject) return;

--- a/src/lib/components/MainView/ProjectViewer.svelte
+++ b/src/lib/components/MainView/ProjectViewer.svelte
@@ -108,24 +108,23 @@
 
     // Called to reset the canvas size to match the container
     function setCanvasSize(initializingProject = false) {
-        // Update the canvas state
-        if (!containerElement)
-            throw new Error("Cannot set canvas size when the container doesn't exist");
-        const pixelRatio = window.devicePixelRatio;
-        canvasElement2D.width = containerElement.clientWidth * pixelRatio;
-        canvasElement2D.height = containerElement.clientHeight * pixelRatio;
-        canvasElementWebGL.width = containerElement.clientWidth * pixelRatio;
-        canvasElementWebGL.height = containerElement.clientHeight * pixelRatio;
-
         // If initializing the project, reset the shared canvas styles (in case set by last project)
-        // and don't call the project's resize method
         if (initializingProject) {
             canvasElement2D.removeAttribute('style');
             canvasElementWebGL.removeAttribute('style');
-            return;
         }
 
+        // Update the internal canvas sizes to match their style sizing
+        if (!containerElement)
+            throw new Error("Cannot set canvas size when the container doesn't exist");
+        const pixelRatio = window.devicePixelRatio;
+        canvasElement2D.width = canvasElement2D.offsetWidth * pixelRatio;
+        canvasElement2D.height = canvasElement2D.offsetHeight * pixelRatio;
+        canvasElementWebGL.width = canvasElementWebGL.offsetWidth * pixelRatio;
+        canvasElementWebGL.height = canvasElementWebGL.offsetHeight * pixelRatio;
+
         // Call the project's resize method (if not initializing)
+        if (initializingProject) return;
         const containerSize: [number, number] = [
             containerElement.clientWidth,
             containerElement.clientHeight

--- a/src/lib/components/MainView/ProjectViewer.svelte
+++ b/src/lib/components/MainView/ProjectViewer.svelte
@@ -97,7 +97,7 @@
                 : undefined;
 
         // Initialize the new project
-        if (shouldResize) setCanvasSize(false);
+        setCanvasSize(true);
         newProject.init();
 
         // Update component & DOM state
@@ -107,7 +107,7 @@
     }
 
     // Called to reset the canvas size to match the container
-    function setCanvasSize(callProjectResize = true) {
+    function setCanvasSize(initializingProject = false) {
         // Update the canvas state
         if (!containerElement)
             throw new Error("Cannot set canvas size when the container doesn't exist");
@@ -117,8 +117,15 @@
         canvasElementWebGL.width = containerElement.clientWidth * pixelRatio;
         canvasElementWebGL.height = containerElement.clientHeight * pixelRatio;
 
-        // Call the project's resize method when appropriate
-        if (!callProjectResize) return;
+        // If initializing the project, reset the shared canvas styles (in case set by last project)
+        // and don't call the project's resize method
+        if (initializingProject) {
+            canvasElement2D.removeAttribute('style');
+            canvasElementWebGL.removeAttribute('style');
+            return;
+        }
+
+        // Call the project's resize method (if not initializing)
         const containerSize: [number, number] = [
             containerElement.clientWidth,
             containerElement.clientHeight
@@ -158,14 +165,26 @@
 </div>
 
 <style lang="scss">
+    :global(canvas) {
+        background-color: $canvas-bg-color;
+        box-shadow: $canvas-shadow;
+    }
+
     #container {
         width: 100%;
         height: 100%;
+        background-color: $container-bg-color;
+
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 
     .shared-canvas {
         width: 100%;
         height: 100%;
+        max-width: 100%;
+        max-height: 100%;
 
         &.hidden {
             display: none;

--- a/src/lib/components/MainView/ProjectViewer.svelte
+++ b/src/lib/components/MainView/ProjectViewer.svelte
@@ -6,6 +6,8 @@
 
     export let project: Project;
     export let containerResizing = false;
+    export let canvasSizeConfig: [number, number] | undefined;
+    export let pixelRatioConfig: number | undefined;
 
     let previousProject: Project | undefined;
     let canvasElement2D: HTMLCanvasElement;
@@ -108,16 +110,25 @@
 
     // Called to reset the canvas size to match the container
     function setCanvasSize(initializingProject = false) {
+        const pixelRatio = pixelRatioConfig ?? window.devicePixelRatio;
+
         // If initializing the project, reset the shared canvas styles (in case set by last project)
         if (initializingProject) {
             canvasElement2D.removeAttribute('style');
             canvasElementWebGL.removeAttribute('style');
+
+            // If the project configures a canvas size, set it
+            if (canvasSizeConfig) {
+                canvasElement2D.style.width = `${canvasSizeConfig[0] / pixelRatio}px`;
+                canvasElement2D.style.height = `${canvasSizeConfig[1] / pixelRatio}px`;
+                canvasElementWebGL.style.width = `${canvasSizeConfig[0] / pixelRatio}px`;
+                canvasElementWebGL.style.height = `${canvasSizeConfig[1] / pixelRatio}px`;
+            }
         }
 
         // Update the internal canvas sizes to match their style sizing
         if (!containerElement)
             throw new Error("Cannot set canvas size when the container doesn't exist");
-        const pixelRatio = window.devicePixelRatio;
         canvasElement2D.width = canvasElement2D.offsetWidth * pixelRatio;
         canvasElement2D.height = canvasElement2D.offsetHeight * pixelRatio;
         canvasElementWebGL.width = canvasElementWebGL.offsetWidth * pixelRatio;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,8 +9,8 @@
         width: 100%;
         height: 100%;
         overflow: hidden;
+        background-color: $app-bg-color;
         box-sizing: content-box; // unset non-standard box-sizing: border-box (ress)
-        background-color: black; // for header on mobile safari, and behind transparent canvases
     }
 
     :global(body) {


### PR DESCRIPTION
No longer must canvas sizes fill the whole container! They still do by default, but a project configuration setting (`canvasSize` in config.json) can set them to a particular pixel size. Pixel ratio still defaults to the device ratio, but can be set in config.json (`pixelRatio`) as well.

Sketchbook will also now allow changing of canvas sizing within projects, e.g. how canvas-sketch likes to do things. The project builder must keep in mind: canvas sizing (style) maxes out at the full container size, and when adjusting canvas style size, they must also adjust internal drawing sizes.