### PR TITLE
App settings: panel state w/ redirect

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -2,7 +2,7 @@
 
 Sketchbook offers a number of settings that influence the behavior of the web app. Each of these settings can be configured within `src/config/settings.ts`, and also can be added to the "Settings" UI, shown by clicking the settings button at the bottom of the project list panel.
 
-The [demo deployment](https://demo.skbk.cc) has all settings options visible and adjustable in the settings panel:
+The [demo deployment](https://demo.skbk.cc) has a majority of settings options visible and adjustable in the settings panel:
 
 <img src="media/settings.png" style="width: 400px" />
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sketchbook2",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "private": true,
     "scripts": {
         "dev": "vite dev",

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -22,6 +22,11 @@ const overlayPanels = true;
 const projectListPanelState = PanelState.Visible;
 const projectDetailPanelState = PanelState.Visible;
 
+// Sketchbook redirects root navigation to the first project listed. In this case, you can override
+// persisted or default project panel state, e.g. showing the project list panel on root navigation.
+const projectListRedirectOverride = true;
+const projectListRedirectOverrideState = PanelState.Visible;
+
 // When using mouse-triggering options for the project list and detail panels above, this is the
 // width of the trigger areas on the left & right, in pixels.
 const panelMouseTriggerWidth = 50;
@@ -55,6 +60,8 @@ export const config = {
     overlayPanels,
     projectListPanelState,
     projectDetailPanelState,
+    projectListRedirectOverride,
+    projectListRedirectOverrideState,
     panelMouseTriggerWidth,
     hidePanelButtonsTimeout,
     projectSortOrder,

--- a/src/lib/base/Util/PersistedStore.ts
+++ b/src/lib/base/Util/PersistedStore.ts
@@ -1,7 +1,7 @@
+import { dev } from '$app/environment';
 import Cookies from 'js-cookie';
 import { writable } from 'svelte/store';
 import type { AnyParamValueType } from '../ConfigModels/ParamTypes';
-import { dev } from '$app/environment';
 
 /**
  * Custom Svelte store that enables persistence of only specified entries in cookies. These values

--- a/src/lib/components/MainView/MainView.svelte
+++ b/src/lib/components/MainView/MainView.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-    import { onDestroy, onMount } from 'svelte';
+    import { getContext, onDestroy, onMount } from 'svelte';
     import { fade } from 'svelte/transition';
 
     import ProjectListPanel from '$lib/components/ProjectListPanel/ProjectListPanel.svelte';
     import SettingsPanel from '../SettingsPanel/SettingsPanel.svelte';
 
     import { content } from '$config/content';
-    import { settingsStore, stateStore } from '$lib/base/Util/AppState';
     import type { ProjectConfig } from '$lib/base/ConfigModels/ProjectConfig';
-    import {
-        PanelState,
-        toggledPanelState,
-        panelShown,
-        headerIconForPanelState
-    } from '$lib/base/Util/PanelState';
+    import { settingsStore, stateStore } from '$lib/base/Util/AppState';
     import { MouseState, mouseStateTransition } from '$lib/base/Util/MouseState';
+    import {
+        headerIconForPanelState,
+        panelShown,
+        PanelState,
+        toggledPanelState
+    } from '$lib/base/Util/PanelState';
     import ProjectSelector from '../ProjectListPanel/ProjectSelector.svelte';
 
     export let projectConfigs: Record<string, ProjectConfig>;
@@ -25,6 +25,12 @@
 
     // UI activity timeout; show panel buttons when active (state maintained in stateStore)
     let uiActiveTimeout: ReturnType<typeof setTimeout>;
+
+    // Apply redirect override to project list state
+    const pageRedirected = getContext('pageRedirected');
+    if (pageRedirected && $settingsStore.projectListRedirectOverride) {
+        $settingsStore.projectListPanelState = $settingsStore.projectListRedirectOverrideState;
+    }
 
     // Left panel reactive state
     $: leftPanelAvailable = $settingsStore.projectListPanelState !== PanelState.Unavailable;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,26 @@
 <script lang="ts">
-    import 'ress';
-    import type { LayoutData } from './$types';
-    import MainView from '$lib/components/MainView/MainView.svelte';
+    import { goto } from '$app/navigation';
     import { page } from '$app/stores';
+    import MainView from '$lib/components/MainView/MainView.svelte';
+    import 'ress';
+    import { onMount, setContext } from 'svelte';
+    import type { LayoutData } from './$types';
 
     export let data: LayoutData;
     $: selectedProjectKey = $page.url.pathname.split('/')[1];
+
+    // Set a context flag if page was redirected via URL param
+    let pageRedirected = $page.url.searchParams.get('redirect') != undefined;
+    setContext('pageRedirected', pageRedirected);
+
+    // Remove redirect param
+    onMount(() => {
+        if (pageRedirected) {
+            const url = new URL($page.url);
+            url.searchParams.delete('redirect');
+            goto(url.toString(), { replaceState: true });
+        }
+    });
 </script>
 
 <MainView projectConfigs={data.projects} {selectedProjectKey}>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,8 +1,8 @@
+import { redirect } from '@sveltejs/kit';
+import isbot from 'isbot';
 import { config } from '../config/settings';
 import ProjectPresentation, { SortOrder } from '../lib/base/ProjectLoading/ProjectPresentation';
 import type { PageServerLoad, PageServerLoadEvent } from './$types';
-import { redirect } from '@sveltejs/kit';
-import isbot from 'isbot';
 
 export const load: PageServerLoad = async ({ parent, cookies, request }: PageServerLoadEvent) => {
     const { projects } = await parent();
@@ -32,6 +32,6 @@ export const load: PageServerLoad = async ({ parent, cookies, request }: PageSer
     // If there are projects, redirect to the first one
     if (presentationOrder.length !== 0 && !isBot) {
         const firstProject = presentationOrder[0];
-        throw redirect(307, `/${firstProject}`);
+        throw redirect(307, `/${firstProject}?redirect`);
     }
 };

--- a/tests/component/MainView.test.ts
+++ b/tests/component/MainView.test.ts
@@ -30,6 +30,61 @@ describe('MainView layout', () => {
     });
 });
 
+describe('Redirect override for project list panel state', () => {
+    afterEach(cleanup);
+
+    it('redirects to the project list panel if the redirect override is set', async () => {
+        settingsStore.set({
+            ...get(settingsStore),
+            projectListPanelState: PanelState.Hidden,
+            projectListRedirectOverride: true,
+            projectListRedirectOverrideState: PanelState.Visible
+        });
+
+        render(MainViewWithContent, {
+            context: new Map(Object.entries({ pageRedirected: true }))
+        });
+
+        await waitFor(() =>
+            expect(get(settingsStore).projectListPanelState).toBe(PanelState.Visible)
+        );
+    });
+
+    it('does not redirect to the project list panel if not redirected', async () => {
+        settingsStore.set({
+            ...get(settingsStore),
+            projectListPanelState: PanelState.Hidden,
+            projectListRedirectOverride: true,
+            projectListRedirectOverrideState: PanelState.Visible
+        });
+
+        render(MainViewWithContent, {
+            context: new Map(Object.entries({ pageRedirected: false }))
+        });
+
+        await waitFor(() =>
+            expect(get(settingsStore).projectListPanelState).toBe(PanelState.Hidden)
+        );
+    });
+
+    it('does not redirect to the project list panel if the redirect override is disabled', async () => {
+        settingsStore.set({
+            ...get(settingsStore),
+            projectListPanelState: PanelState.Hidden,
+            projectListRedirectOverride: false,
+            projectListRedirectOverrideState: PanelState.Visible
+        });
+
+        render(MainViewWithContent, {
+            context: new Map(Object.entries({ pageRedirected: true }))
+        });
+
+        await waitFor(() =>
+            expect(get(settingsStore).projectListPanelState).toBe(PanelState.Hidden)
+        );
+    });
+});
+
 describe('Panel button visibility', () => {
     afterEach(cleanup);
 


### PR DESCRIPTION
Now you can optionally set up override behavior for the project list when sketchbook redirects from a root navigation (e.g. `https://longitude.studio`) to the first project listed. In this case, we may want to e.g. show the project list always, because user intent is to see all projects available. This will then persist as the new project list state, e.g on refresh or future direct project linking, until adjusted by the user.

In keeping with the principles of the Sketchbook project, these settings have been made maximally configurable - you can use any state override in the redirect case! But setting this to "visible" is the most likely use case.