### PR TITLE
Custom canvas sizing from project settings

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -46,12 +46,19 @@ const alwaysShowPresets = false;
 // These files can be added directly to a project's `presets` directory and used as bundled presets.
 const enablePresetExport = dev;
 
+// Canvas size can be fullscreen, or fixed to defaultCanvasSize. Projects may specify a canvasSize
+// configuration value to avoid fullscreen rendering and override the defaultCanvasSize.
+const defaultCanvasSize = [1080, 1080];
+const useFullscreenCanvas = true;
+
 // Anything listed here will appear in the user settings panel with the given label. Values changed
 // in the settings panel will be persisted in cookies, and values above will be used as defaults.
 export const userSettingsLabels: Record<string, string> = {
     projectSortOrder: 'Project Sorting',
     showExperiments: 'Show Experiments',
-    overlayPanels: 'Overlay Panels'
+    overlayPanels: 'Overlay Panels',
+    defaultCanvasSize: 'Default Canvas Size',
+    useFullscreenCanvas: 'Use Fullscreen Canvas'
 };
 
 // Export all settings for use elsewhere in the app.
@@ -67,5 +74,7 @@ export const config = {
     projectSortOrder,
     groupSortOrder,
     alwaysShowPresets,
-    enablePresetExport
+    enablePresetExport,
+    useFullscreenCanvas,
+    defaultCanvasSize
 };

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -57,7 +57,7 @@ export const userSettingsLabels: Record<string, string> = {
     projectSortOrder: 'Project Sorting',
     showExperiments: 'Show Experiments',
     overlayPanels: 'Overlay Panels',
-    useFullscreenCanvas: 'Use Fullscreen Canvas',
+    useFullscreenCanvas: 'Fullscreen Canvas',
     defaultCanvasSize: 'Default Canvas Size'
 };
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -48,8 +48,8 @@ const enablePresetExport = dev;
 
 // Canvas size can be fullscreen, or fixed to defaultCanvasSize. Projects may specify a canvasSize
 // configuration value to avoid fullscreen rendering and override the defaultCanvasSize.
-const defaultCanvasSize = [1080, 1080];
 const useFullscreenCanvas = true;
+const defaultCanvasSize = [1080, 1080];
 
 // Anything listed here will appear in the user settings panel with the given label. Values changed
 // in the settings panel will be persisted in cookies, and values above will be used as defaults.
@@ -57,8 +57,8 @@ export const userSettingsLabels: Record<string, string> = {
     projectSortOrder: 'Project Sorting',
     showExperiments: 'Show Experiments',
     overlayPanels: 'Overlay Panels',
-    defaultCanvasSize: 'Default Canvas Size',
-    useFullscreenCanvas: 'Use Fullscreen Canvas'
+    useFullscreenCanvas: 'Use Fullscreen Canvas',
+    defaultCanvasSize: 'Default Canvas Size'
 };
 
 // Export all settings for use elsewhere in the app.
@@ -75,6 +75,6 @@ export const config = {
     groupSortOrder,
     alwaysShowPresets,
     enablePresetExport,
-    useFullscreenCanvas,
-    defaultCanvasSize
+    defaultCanvasSize,
+    useFullscreenCanvas
 };

--- a/src/lib/components/MainView/ProjectContent.svelte
+++ b/src/lib/components/MainView/ProjectContent.svelte
@@ -2,16 +2,16 @@
     import ProjectDetailPanel from '../ProjectDetailPanel/ProjectDetailPanel.svelte';
     import ProjectViewer from './ProjectViewer.svelte';
 
+    import { content } from '$config/content';
     import type { ProjectTuple } from '$lib/base/ProjectLoading/ProjectLoader';
     import { settingsStore, stateStore } from '$lib/base/Util/AppState';
+    import { MouseState } from '$lib/base/Util/MouseState';
     import {
         PanelState,
         headerIconForPanelState,
         panelShown,
         toggledPanelState
     } from '$lib/base/Util/PanelState';
-    import { MouseState } from '$lib/base/Util/MouseState';
-    import { content } from '$config/content';
     import PresetSelector from '../ProjectDetailPanel/PresetSelector.svelte';
 
     export let projectTuple: ProjectTuple;

--- a/src/lib/components/ProjectDetailPanel/ParamItem.svelte
+++ b/src/lib/components/ProjectDetailPanel/ParamItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-    import { createEventDispatcher } from 'svelte';
     import type { ParamConfig } from '$lib/base/ConfigModels/ParamConfig';
     import { ParamGuards, type AnyParamValueType } from '$lib/base/ConfigModels/ParamTypes';
+    import { createEventDispatcher } from 'svelte';
     import BooleanInput from '../Inputs/BooleanInput.svelte';
     import FunctionInput from '../Inputs/FunctionInput.svelte';
     import NumberInput from '../Inputs/NumberInput.svelte';
@@ -14,8 +14,8 @@
     } from '$lib/base/ConfigModels/ParamConfigs/NumericArrayParamConfig';
     import { StringParamStyle } from '$lib/base/ConfigModels/ParamConfigs/StringParamConfig';
     import ColorInput from '../Inputs/ColorInput.svelte';
-    import OptionInput from '../Inputs/OptionInput.svelte';
     import FileInput from '../Inputs/FileInput.svelte';
+    import OptionInput from '../Inputs/OptionInput.svelte';
 
     export let config: ParamConfig;
     export let value: AnyParamValueType;
@@ -275,6 +275,7 @@
 
     .compact {
         grid-template-columns: 1fr 1fr;
+        max-width: calc($param-input-item-partial-width * 2);
     }
 
     .unavailable-param {

--- a/src/lib/components/ProjectListPanel/ProjectList.svelte
+++ b/src/lib/components/ProjectListPanel/ProjectList.svelte
@@ -22,7 +22,7 @@
             const selectedElement = document.querySelector(
                 '.project-list-item.selected'
             ) as HTMLElement;
-            if (selectedElement) {
+            if (selectedElement && selectedElement.scrollIntoView) {
                 selectedElement.scrollIntoView({ behavior: 'instant', block: 'nearest' });
                 // Scroll a little more if the selected element is near the bottom of the container
                 const container = selectedElement.parentElement as HTMLElement;

--- a/src/lib/components/SettingsPanel/SettingsParamConfigs.ts
+++ b/src/lib/components/SettingsPanel/SettingsParamConfigs.ts
@@ -1,18 +1,23 @@
+import { userSettingsLabels } from '$config/settings';
 import type { ParamConfig } from '$lib/base/ConfigModels/ParamConfig';
 import {
     BooleanParamConfigDefaults,
     type BooleanParamConfig
 } from '$lib/base/ConfigModels/ParamConfigs/BooleanParamConfig';
 import {
+    NumberParamConfigDefaults,
+    NumberParamStyle,
+    type NumberParamConfig
+} from '$lib/base/ConfigModels/ParamConfigs/NumberParamConfig';
+import {
+    NumericArrayParamConfigDefaults,
+    NumericArrayParamStyle,
+    type NumericArrayParamConfig
+} from '$lib/base/ConfigModels/ParamConfigs/NumericArrayParamConfig';
+import {
     StringParamConfigDefaults,
     type StringParamConfig
 } from '$lib/base/ConfigModels/ParamConfigs/StringParamConfig';
-import { userSettingsLabels } from '$config/settings';
-import {
-    NumberParamConfigDefaults,
-    type NumberParamConfig,
-    NumberParamStyle
-} from '$lib/base/ConfigModels/ParamConfigs/NumberParamConfig';
 
 // ParamConfigs for each possible entry in the Settings panel
 export const settingsParamConfigs: ParamConfig[] = [
@@ -107,7 +112,23 @@ export const settingsParamConfigs: ParamConfig[] = [
     {
         ...BooleanParamConfigDefaults,
         key: 'enablePresetExport'
-    } as BooleanParamConfig
+    } as BooleanParamConfig,
+
+    // useFullscreenCanvas
+    {
+        ...BooleanParamConfigDefaults,
+        key: 'useFullscreenCanvas'
+    } as BooleanParamConfig,
+
+    // defaultCanvasSize
+    {
+        ...NumericArrayParamConfigDefaults,
+        style: NumericArrayParamStyle.CompactField,
+        min: 0,
+        max: 5000,
+        step: 1,
+        key: 'defaultCanvasSize'
+    } as NumericArrayParamConfig
 ].map((paramConfig) => {
     // Add the label to each ParamConfig from config/settings.ts
     paramConfig.name = userSettingsLabels[paramConfig.key];

--- a/tests/component/MainView.test.ts
+++ b/tests/component/MainView.test.ts
@@ -1,10 +1,10 @@
-import { render, fireEvent, screen, cleanup, waitFor, within } from '@testing-library/svelte';
-import { vi, describe, it, expect, afterEach } from 'vitest';
-import MainViewWithContent from '$lib/components/TestComponents/MainViewWithContent.svelte';
 import { settingsStore, stateStore } from '$lib/base/Util/AppState';
-import { get } from 'svelte/store';
 import { PanelState } from '$lib/base/Util/PanelState';
+import MainViewWithContent from '$lib/components/TestComponents/MainViewWithContent.svelte';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Mocking for getContext is required for HTMLCanvasElement to work with Jest/Vitest
 // https://github.com/hustcc/jest-canvas-mock/issues/2


### PR DESCRIPTION
This PR adds canvas sizing to the project settings. The values configured by these can still be overridden by the `canvasSize` in a project's config.

<img width="694" alt="image" src="https://github.com/user-attachments/assets/112c3cb5-5ec8-4271-b95b-0740a8f70b26">
